### PR TITLE
Two small changes for the demo

### DIFF
--- a/.changeset/six-pianos-punch.md
+++ b/.changeset/six-pianos-punch.md
@@ -1,0 +1,5 @@
+---
+'@sillsdev/lynx-punctuation-checker': patch
+---
+
+Expand allowed characters for demo and only correct the typed character with smart quotes

--- a/package-lock.json
+++ b/package-lock.json
@@ -7536,7 +7536,7 @@
     },
     "packages/core": {
       "name": "@sillsdev/lynx",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "i18next": "^23.16.5",
@@ -7554,7 +7554,7 @@
     },
     "packages/delta": {
       "name": "@sillsdev/lynx-delta",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@sillsdev/lynx": "^0.3.0",
@@ -7603,10 +7603,10 @@
     },
     "packages/punctuation-checker": {
       "name": "@sillsdev/lynx-punctuation-checker",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/lynx": "^0.3.1",
+        "@sillsdev/lynx": "^0.3.3",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {

--- a/packages/punctuation-checker/src/rule-set/standard-rule-sets.ts
+++ b/packages/punctuation-checker/src/rule-set/standard-rule-sets.ts
@@ -18,9 +18,14 @@ export class StandardRuleSets {
         .addRange('a', 'z')
         .addRange('0', '9')
         .addCharacters(['.', ',', '?', '/', '\\', ':', ';', '(', ')', '[', ']', '-', '–', '—', '!'])
-        .addCharacters(['"', "'", '\u2018', '\u2019', '\u201C', '\u201D'])
+        .addCharacters(['"', "'", '\u2018', '\u2019', '\u201C', '\u201D', '\u02BC'])
         .addCharacters([' ', '\r', '\n', '\t'])
         .addCharacters(['…'])
+        .addCharacters(['\uA78C']) // Temporary additions to handle non-English Latin scripts
+        .addRange('\u00C0', '\u00F6')
+        .addRange('\u00F8', '\u02AF')
+        .addRange('\u1E00', '\u1EFF')
+
         .build(),
     ),
     new QuotationConfig.Builder()

--- a/packages/punctuation-checker/test/allowed-character/allowed-character-checker.test.ts
+++ b/packages/punctuation-checker/test/allowed-character/allowed-character-checker.test.ts
@@ -226,8 +226,10 @@ describe('integration tests', () => {
       expect(await standardEnglishCharacterChecker.getDiagnostics('‟″á×ꭗﬁ')).toEqual([
         testEnv.createExpectedDiagnostic('‟', 0, 1),
         testEnv.createExpectedDiagnostic('″', 1, 2),
-        testEnv.createExpectedDiagnostic('á', 2, 3),
-        testEnv.createExpectedDiagnostic('×', 3, 4),
+
+        // These tests should be re-added once we add support for non-English
+        //testEnv.createExpectedDiagnostic('á', 2, 3),
+        //testEnv.createExpectedDiagnostic('×', 3, 4),
         testEnv.createExpectedDiagnostic('ꭗ', 4, 5),
         testEnv.createExpectedDiagnostic('ﬁ', 5, 6),
       ]);

--- a/packages/punctuation-checker/test/quotation/quotation-corrector.test.ts
+++ b/packages/punctuation-checker/test/quotation/quotation-corrector.test.ts
@@ -43,160 +43,155 @@ describe('Text quote correction tests', () => {
 
   it('corrects ambiguous quotation marks', async () => {
     const testEnv: TextTestEnvironment = TextTestEnvironment.createWithFullEnglishQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time...', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time...', { line: 0, character: 1 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time..."', arbitraryPosition, arbitraryCharacter),
-    ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1), testEnv.createExpectedEdit('\u201D', 20, 21)]);
+      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time..."', { line: 0, character: 1 }, '"'),
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
-        '\u201COnce upon a time..."',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
+      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time..."', { line: 0, character: 21 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 20, 21)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
-        '"Once upon a time...\u201D',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
+      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time..."', { line: 0, character: 21 }, '"'),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 20, 21)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time...\u201D', { line: 0, character: 1 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         "\u201CIt was the best of times, 'it was the worst of times\u2019\u201D",
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 28 },
+        "'",
       ),
     ).toEqual([testEnv.createExpectedEdit('\u2018', 27, 28)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         "\u201CIt was the best of times, \u2018it was the worst of times'\u201D",
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 54 },
+        "'",
       ),
     ).toEqual([testEnv.createExpectedEdit('\u2019', 53, 54)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\u201CIt was the best of times, \u2018it was the worst of times\u2019"',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 55 },
+        '"',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 54, 55)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '"It was the best of times, \'it was the worst of times\'"',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 1 },
+        '"',
       ),
-    ).toEqual([
-      testEnv.createExpectedEdit('\u201C', 0, 1),
-      testEnv.createExpectedEdit('\u2018', 27, 28),
-      testEnv.createExpectedEdit('\u2019', 53, 54),
-      testEnv.createExpectedEdit('\u201D', 54, 55),
-    ]);
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits(
+        '"It was the best of times, \'it was the worst of times\'"',
+        { line: 0, character: 28 },
+        "'",
+      ),
+    ).toEqual([testEnv.createExpectedEdit('\u2018', 27, 28)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits(
+        '"It was the best of times, \'it was the worst of times\'"',
+        { line: 0, character: 54 },
+        "'",
+      ),
+    ).toEqual([testEnv.createExpectedEdit('\u2019', 53, 54)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits(
+        '"It was the best of times, \'it was the worst of times\'"',
+        { line: 0, character: 55 },
+        '"',
+      ),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 54, 55)]);
   });
 
   it('does not depend on whitespace', async () => {
     const testEnv: TextTestEnvironment = TextTestEnvironment.createWithFullEnglishQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time...', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('"Once upon a time...', { line: 0, character: 1 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(' "Once upon a time...', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits(' "Once upon a time...', { line: 0, character: 2 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 1, 2)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('" Once upon a time...', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('" Once upon a time...', { line: 0, character: 1 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 1)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('Once upon a time..."', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('Once upon a time..."', { line: 0, character: 20 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 19, 20)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
-        '\u201COnce upon a time..."',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
+      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time..."', { line: 0, character: 21 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 20, 21)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time"', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time"', { line: 0, character: 18 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 17, 18)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
-        '\u201COnce upon a time" ',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
+      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time" ', { line: 0, character: 18 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 17, 18)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
-        '\u201COnce upon a time "',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
+      await testEnv.quotationCorrector.getOnTypeEdits('\u201COnce upon a time "', { line: 0, character: 19 }, '"'),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 18, 19)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('Once" upon a time "there was', { line: 0, character: 5 }, '"'),
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 4, 5)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('Once" upon a time "there was', { line: 0, character: 19 }, '"'),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 18, 19)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
-        'Once" upon a time "there was',
-        arbitraryPosition,
-        arbitraryCharacter,
-      ),
-    ).toEqual([testEnv.createExpectedEdit('\u201C', 4, 5), testEnv.createExpectedEdit('\u201D', 18, 19)]);
-
-    expect(
-      await testEnv.quotationCorrector.getOnTypeEdits(
         "\u201COnce upon' a time there \u2019was\u201D",
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 11 },
+        "'",
       ),
     ).toEqual([testEnv.createExpectedEdit('\u2018', 10, 11)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         "\u201COnce upon 'a time there \u2019was\u201D",
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 12 },
+        "'",
       ),
     ).toEqual([testEnv.createExpectedEdit('\u2018', 11, 12)]);
   });
 
-  it('does not depend on the position or character passed', async () => {
+  it('does not depend on the character passed', async () => {
     const testEnv: TextTestEnvironment = TextTestEnvironment.createWithFullEnglishQuotes();
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('It was the "best of times', { line: 0, character: 10 }, 'c'),
-    ).toEqual([testEnv.createExpectedEdit('\u201C', 11, 12)]);
-
-    expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('It was the "best of times', { line: 10, character: 0 }, '"'),
+      await testEnv.quotationCorrector.getOnTypeEdits('It was the "best of times', { line: 0, character: 12 }, 'c'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 11, 12)]);
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         'It was the "best of times',
-        { line: 25, character: 35 },
+        { line: 0, character: 12 },
         '\u201D',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 11, 12)]);
@@ -204,7 +199,7 @@ describe('Text quote correction tests', () => {
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         'It was the "best of times',
-        { line: 250, character: 350 },
+        { line: 0, character: 12 },
         '\u201C',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 11, 12)]);
@@ -212,86 +207,93 @@ describe('Text quote correction tests', () => {
 
   it('adheres to the QuotationConfig', async () => {
     const testEnv: TextTestEnvironment = TextTestEnvironment.createWithAlternativeAmbiguousQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon a time', arbitraryPosition, arbitraryCharacter),
+      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon a time', { line: 0, character: 6 }, '+'),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 5, 6)]);
 
     expect(
-      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon- a time-+', arbitraryPosition, arbitraryCharacter),
-    ).toEqual([
-      testEnv.createExpectedEdit('\u201C', 5, 6),
-      testEnv.createExpectedEdit('\u2018', 10, 11),
-      testEnv.createExpectedEdit('\u2019', 18, 19),
-      testEnv.createExpectedEdit('\u201D', 19, 20),
-    ]);
+      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon- a time-+', { line: 0, character: 6 }, '+'),
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 5, 6)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon- a time-+', { line: 0, character: 11 }, '-'),
+    ).toEqual([testEnv.createExpectedEdit('\u2018', 10, 11)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon- a time-+', { line: 0, character: 19 }, '-'),
+    ).toEqual([testEnv.createExpectedEdit('\u2019', 18, 19)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits('Once +upon- a time-+', { line: 0, character: 20 }, '+'),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 19, 20)]);
   });
 });
 
 describe('Scripture quote correction tests', () => {
   it('corrects ambiguous quotation marks in single ScriptureNodes', async () => {
     const testEnv: ScriptureTestEnvironment = ScriptureTestEnvironment.createWithFullEnglishQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\\c 1 \\v 1 verse with \u201Cambiguous quote"',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 38 },
+        '"',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 0, 37, 0, 38)]);
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\\c 1 \\v 1 verse with \u201Cunambiguous quote \\v 2 and verse" with',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 55 },
+        '"',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 0, 54, 0, 55)]);
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         `\\c 1
          \\v 1 verse with \u201Cambiguous quote"`,
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 1, character: 42 },
+        '"',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201D', 1, 41, 1, 42)]);
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\\toc "book name \\c 1 \\v 1 verse text',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 6 },
+        '"',
       ),
     ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 5, 0, 6)]);
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\\toc \u201Cbook name \\c 1 \\v 1 verse\u201D text',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 6 },
+        '"',
       ),
     ).toEqual([]);
   });
 
   it('corrects multiple ambiguous quotation marks in a single ScriptureNode', async () => {
     const testEnv: ScriptureTestEnvironment = ScriptureTestEnvironment.createWithFullEnglishQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
         '\\c 1 \\v 1 verse with "ambiguous quotes"',
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 0, character: 22 },
+        '"',
       ),
-    ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 21, 0, 22), testEnv.createExpectedEdit('\u201D', 0, 38, 0, 39)]);
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 0, 21, 0, 22)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits(
+        '\\c 1 \\v 1 verse with "ambiguous quotes"',
+        { line: 0, character: 39 },
+        '"',
+      ),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 0, 38, 0, 39)]);
   });
 
   it('corrects ambiguous quotation marks in quotes stretching across multiple ScriptureNodes', async () => {
     const testEnv: ScriptureTestEnvironment = ScriptureTestEnvironment.createWithFullEnglishQuotes();
-    const arbitraryPosition: Position = { line: 0, character: 0 };
-    const arbitraryCharacter = 'a';
 
     expect(
       await testEnv.quotationCorrector.getOnTypeEdits(
@@ -299,10 +301,21 @@ describe('Scripture quote correction tests', () => {
          \\v 1 verses with "ambiguous
          \\v 2 quotes" and
          \\v 3 another verse at the end`,
-        arbitraryPosition,
-        arbitraryCharacter,
+        { line: 1, character: 27 },
+        '"',
       ),
-    ).toEqual([testEnv.createExpectedEdit('\u201C', 1, 26, 1, 27), testEnv.createExpectedEdit('\u201D', 2, 20, 2, 21)]);
+    ).toEqual([testEnv.createExpectedEdit('\u201C', 1, 26, 1, 27)]);
+
+    expect(
+      await testEnv.quotationCorrector.getOnTypeEdits(
+        `\\c 1
+         \\v 1 verses with "ambiguous
+         \\v 2 quotes" and
+         \\v 3 another verse at the end`,
+        { line: 2, character: 21 },
+        '"',
+      ),
+    ).toEqual([testEnv.createExpectedEdit('\u201D', 2, 20, 2, 21)]);
   });
 });
 

--- a/packages/punctuation-checker/test/rule-set/rule-set.test.ts
+++ b/packages/punctuation-checker/test/rule-set/rule-set.test.ts
@@ -227,9 +227,10 @@ describe('DiagnosticProviderFactory tests', () => {
 
     expect(onTypeFormatters[0].id).toEqual('quote-corrector');
 
-    expect(await onTypeFormatters[0].getOnTypeEdits('A', { line: 0, character: 0 }, '')).toBe(undefined);
-    expect(await onTypeFormatters[0].getOnTypeEdits('+A', { line: 0, character: 0 }, '')).toHaveLength(1);
-    expect(await onTypeFormatters[0].getOnTypeEdits('+A+', { line: 0, character: 0 }, '')).toHaveLength(2);
+    expect(await onTypeFormatters[0].getOnTypeEdits('A', { line: 0, character: 1 }, '')).toBe(undefined);
+    expect(await onTypeFormatters[0].getOnTypeEdits('+A', { line: 0, character: 1 }, '')).toHaveLength(1);
+    expect(await onTypeFormatters[0].getOnTypeEdits('+A+', { line: 0, character: 1 }, '')).toHaveLength(1);
+    expect(await onTypeFormatters[0].getOnTypeEdits('+A+', { line: 0, character: 3 }, '')).toHaveLength(1);
   });
 
   it('also accepts a ScriptureDocument factory', async () => {
@@ -261,6 +262,8 @@ describe('DiagnosticProviderFactory tests', () => {
       stubScriptureDocumentManager,
       new UsfmEditFactory(stylesheet),
     );
-    expect(await onTypeFormatters[0].getOnTypeEdits('\\c 1 \\v 1 +A+', { line: 0, character: 0 }, '')).toHaveLength(2);
+    expect(await onTypeFormatters[0].getOnTypeEdits('\\c 1 \\v 1 +A+', { line: 0, character: 11 }, '')).toHaveLength(1);
+    expect(await onTypeFormatters[0].getOnTypeEdits('\\c 1 \\v 1 +A+', { line: 0, character: 12 }, '')).toHaveLength(0);
+    expect(await onTypeFormatters[0].getOnTypeEdits('\\c 1 \\v 1 +A+', { line: 0, character: 13 }, '')).toHaveLength(1);
   });
 });

--- a/packages/punctuation-checker/test/rule-set/standard-rule-sets.test.ts
+++ b/packages/punctuation-checker/test/rule-set/standard-rule-sets.test.ts
@@ -861,8 +861,8 @@ describe('Standard English rule set tests', () => {
       expect(
         await quoteCorrector.getOnTypeEdits(
           `The LORD who rules over all says this: “These people have said, 'The time for rebuilding the LORD's temple has not yet come.’”`,
-          { line: 0, character: 0 },
-          't',
+          { line: 0, character: 65 },
+          "'",
         ),
       ).toEqual([
         {
@@ -877,8 +877,8 @@ describe('Standard English rule set tests', () => {
       expect(
         await quoteCorrector.getOnTypeEdits(
           `The LORD who rules over all says this: “These people have said, ‘The time for rebuilding the LORD's temple has not yet come.’"`,
-          { line: 0, character: 0 },
-          't',
+          { line: 0, character: 126 },
+          '"',
         ),
       ).toEqual([
         {


### PR DESCRIPTION
This pull request contains two minor punctuation checker changes for the demo:

1. It expands the list of allowed characters to (hopefully) cover any Latin script
2. It changes the "smart quotes" feature to only correct the character that the user typed.  It previously changed all ambiguous quotation marks, but this could result in errors when the document contained incorrectly nested or improperly paired quotation marks.

Damien, for the second change, I found that VSCode's `onDocumentOnTypeFormatting` function consistently passed a `Position` whose character offset was one greater than what I was expecting.  I've configured `quotation-corrector.ts` to expect the VSCode-style `Position`, but we should check that ScriptureForge also passes a `Position` that matches VSCode's conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lynx/26)
<!-- Reviewable:end -->
