### PR TITLE
Use esm lodash to fix angular build warning

### DIFF
--- a/.changeset/real-crews-obey.md
+++ b/.changeset/real-crews-obey.md
@@ -1,0 +1,5 @@
+---
+'@sillsdev/lynx-delta': patch
+---
+
+Use esm lodash to fix angular build warning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,20 +1472,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
-      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
-      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4661,6 +4651,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7554,10 +7550,11 @@
     },
     "packages/delta": {
       "name": "@sillsdev/lynx-delta",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@sillsdev/lynx": "^0.3.0",
+        "lodash-es": "^4.17.21",
         "quill-delta": "^5.1.0",
         "uuid": "^11.0.3"
       },
@@ -7565,8 +7562,7 @@
         "@repo/eslint-config": "*",
         "@repo/tsup-config": "*",
         "@repo/typescript-config": "*",
-        "@types/lodash.clonedeep": "^4.5.9",
-        "@types/lodash.isequal": "^4.5.8",
+        "@types/lodash-es": "^4.17.12",
         "eslint": "^9.9.1",
         "tsup": "^8.3.0",
         "typescript": "^5.5.4"
@@ -7603,7 +7599,7 @@
     },
     "packages/punctuation-checker": {
       "name": "@sillsdev/lynx-punctuation-checker",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@sillsdev/lynx": "^0.3.3",

--- a/packages/delta/package.json
+++ b/packages/delta/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@sillsdev/lynx": "^0.3.0",
+    "lodash-es": "^4.17.21",
     "quill-delta": "^5.1.0",
     "uuid": "^11.0.3"
   },
@@ -36,8 +37,7 @@
     "@repo/eslint-config": "*",
     "@repo/tsup-config": "*",
     "@repo/typescript-config": "*",
-    "@types/lodash.clonedeep": "^4.5.9",
-    "@types/lodash.isequal": "^4.5.8",
+    "@types/lodash-es": "^4.17.12",
     "eslint": "^9.9.1",
     "tsup": "^8.3.0",
     "typescript": "^5.5.4"

--- a/packages/delta/src/scripture-delta-document.ts
+++ b/packages/delta/src/scripture-delta-document.ts
@@ -16,7 +16,7 @@ import {
   ScriptureText,
   ScriptureVerse,
 } from '@sillsdev/lynx';
-import isEqual from 'lodash.isequal';
+import isEqual from 'lodash-es/isEqual';
 import Delta, { Op } from 'quill-delta';
 
 import { DeltaDocument, getChangeOffsetRange } from './delta-document';

--- a/packages/delta/src/scripture-delta-edit-factory.ts
+++ b/packages/delta/src/scripture-delta-edit-factory.ts
@@ -11,7 +11,7 @@ import {
   ScriptureRef,
   ScriptureVerse,
 } from '@sillsdev/lynx';
-import cloneDeep from 'lodash.clonedeep';
+import cloneDeep from 'lodash-es/cloneDeep';
 import Delta, { Op } from 'quill-delta';
 import { v4 as uuidv4 } from 'uuid';
 


### PR DESCRIPTION
This PR should fix the warning in SF angular build regarding `CommonJS or AMD dependencies can cause optimization bailouts.`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lynx/42)
<!-- Reviewable:end -->
