### PR TITLE
Add 'en' fallback to locale loader

### DIFF
--- a/.changeset/ten-comics-suffer.md
+++ b/.changeset/ten-comics-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sillsdev/lynx-punctuation-checker': patch
+---
+
+Add 'en' fallback to locale loader

--- a/packages/punctuation-checker/src/allowed-character/allowed-character-checker.ts
+++ b/packages/punctuation-checker/src/allowed-character/allowed-character-checker.ts
@@ -9,6 +9,7 @@ import {
 } from '@sillsdev/lynx';
 
 import { AbstractChecker } from '../abstract-checker';
+import { createLocaleLoader } from '../utils/locale-loader';
 import { AllowedCharacterIssueFinderFactory } from './allowed-character-issue-finder';
 import { AllowedCharacterSet } from './allowed-character-set';
 
@@ -35,13 +36,7 @@ export class AllowedCharacterChecker<
   async init(): Promise<void> {
     await super.init();
 
-    // Ideally, we'd like to be able to inject an initialization function, so that
-    // tests can provide different messages, but due to the way variable dynamic imports
-    // work, the namespace loading function can only appear in this file at this location
-    this.localizer.addNamespace(
-      ALLOWED_CHARACTER_CHECKER_LOCALIZER_NAMESPACE,
-      (language: string) => import(`./locales/${language}.json`, { with: { type: 'json' } }),
-    );
+    this.localizer.addNamespace(ALLOWED_CHARACTER_CHECKER_LOCALIZER_NAMESPACE, createLocaleLoader('allowed-character'));
   }
 
   protected getFixes(_document: TDoc, _diagnostic: Diagnostic): DiagnosticFix<TEdit>[] {

--- a/packages/punctuation-checker/src/fixes/standard-fixes.ts
+++ b/packages/punctuation-checker/src/fixes/standard-fixes.ts
@@ -9,6 +9,8 @@ import {
   TextEdit,
 } from '@sillsdev/lynx';
 
+import { createLocaleLoader } from '../utils/locale-loader';
+
 const LOCALIZER_NAMESPACE = 'standardPunctuationFixes';
 
 class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit = TextEdit> {
@@ -105,13 +107,7 @@ class StandardFixProviderFactory<TDoc extends TextDocument | ScriptureDocument, 
   ) {}
 
   public async init(): Promise<void> {
-    // Ideally, we'd like to be able to inject an initialization function, so that
-    // tests can provide different messages, but due to the way variable dynamic imports
-    // work, the namespace loading function can only appear in this file at this location
-    this.localizer.addNamespace(
-      LOCALIZER_NAMESPACE,
-      (language: string) => import(`./locales/${language}.json`, { with: { type: 'json' } }),
-    );
+    this.localizer.addNamespace(LOCALIZER_NAMESPACE, createLocaleLoader('fixes'));
 
     return Promise.resolve();
   }

--- a/packages/punctuation-checker/src/paired-punctuation/paired-punctuation-checker.ts
+++ b/packages/punctuation-checker/src/paired-punctuation/paired-punctuation-checker.ts
@@ -12,6 +12,7 @@ import {
 import { AbstractChecker } from '../abstract-checker';
 import type { StandardFixProvider } from '../fixes/standard-fixes';
 import { StandardFixProviderFactory } from '../fixes/standard-fixes';
+import { createLocaleLoader } from '../utils/locale-loader';
 import { PairedPunctuationConfig } from './paired-punctuation-config';
 import { PairedPunctuationIssueFinderFactory } from './paired-punctuation-issue-finder';
 
@@ -52,12 +53,9 @@ export class PairedPunctuationChecker<
   async init(): Promise<void> {
     await super.init();
 
-    // Ideally, we'd like to be able to inject an initialization function, so that
-    // tests can provide different messages, but due to the way variable dynamic imports
-    // work, the namespace loading function can only appear in this file at this location
     this.localizer.addNamespace(
       PAIRED_PUNCTUATION_CHECKER_LOCALIZER_NAMESPACE,
-      (language: string) => import(`./locales/${language}.json`, { with: { type: 'json' } }),
+      createLocaleLoader('paired-punctuation'),
     );
 
     await this.standardFixProviderFactory.init();

--- a/packages/punctuation-checker/src/punctuation-context/punctuation-context-checker.ts
+++ b/packages/punctuation-checker/src/punctuation-context/punctuation-context-checker.ts
@@ -11,6 +11,7 @@ import {
 
 import { AbstractChecker } from '../abstract-checker';
 import { StandardFixProvider, StandardFixProviderFactory } from '../fixes/standard-fixes';
+import { createLocaleLoader } from '../utils/locale-loader';
 import { PunctuationContextConfig } from './punctuation-context-config';
 import { PunctuationContextIssueFinderFactory, WhitespaceDiagnosticData } from './punctuation-context-issue-finder';
 
@@ -43,12 +44,9 @@ export class PunctuationContextChecker<
   async init(): Promise<void> {
     await super.init();
 
-    // Ideally, we'd like to be able to inject an initialization function, so that
-    // tests can provide different messages, but due to the way variable dynamic imports
-    // work, the namespace loading function can only appear in this file at this location
     this.localizer.addNamespace(
       PUNCTUATION_CONTEXT_CHECKER_LOCALIZER_NAMESPACE,
-      (language: string) => import(`./locales/${language}.json`, { with: { type: 'json' } }),
+      createLocaleLoader('punctuation-context'),
     );
 
     await this.standardFixProviderFactory.init();

--- a/packages/punctuation-checker/src/quotation/quotation-checker.ts
+++ b/packages/punctuation-checker/src/quotation/quotation-checker.ts
@@ -13,6 +13,7 @@ import { AbstractChecker } from '../abstract-checker';
 import type { StandardFixProvider } from '../fixes/standard-fixes';
 import { StandardFixProviderFactory } from '../fixes/standard-fixes';
 import { PairedPunctuationDirection } from '../utils';
+import { createLocaleLoader } from '../utils/locale-loader';
 import { QuotationConfig } from './quotation-config';
 import { QuotationIssueFinderFactory } from './quotation-issue-finder';
 import { QuotationDepth } from './quotation-utils';
@@ -50,13 +51,7 @@ export class QuotationChecker<TDoc extends TextDocument | ScriptureDocument, TEd
   async init(): Promise<void> {
     await super.init();
 
-    // Ideally, we'd like to be able to inject an initialization function, so that
-    // tests can provide different messages, but due to the way variable dynamic imports
-    // work, the namespace loading function can only appear in this file at this location
-    this.localizer.addNamespace(
-      QUOTATION_CHECKER_LOCALIZER_NAMESPACE,
-      (language: string) => import(`./locales/${language}.json`, { with: { type: 'json' } }),
-    );
+    this.localizer.addNamespace(QUOTATION_CHECKER_LOCALIZER_NAMESPACE, createLocaleLoader('quotation'));
 
     await this.standardFixProviderFactory.init();
   }

--- a/packages/punctuation-checker/src/utils/locale-loader.ts
+++ b/packages/punctuation-checker/src/utils/locale-loader.ts
@@ -1,0 +1,22 @@
+export type LocaleLoader = (language: string) => Promise<unknown>;
+
+/**
+ * Available checker types that have locale support.
+ * These correspond directly to the directory names in the src folder.
+ */
+export type CheckerType = 'allowed-character' | 'quotation' | 'punctuation-context' | 'paired-punctuation' | 'fixes';
+
+/**
+ * Creates a bundler-safe locale loader with fallback to 'en'.
+ * @param checkerType - The type of checker to create a locale loader for
+ * @returns A locale loader function that can load locales for the specified checker
+ */
+export function createLocaleLoader(checkerType: CheckerType): LocaleLoader {
+  return async (language: string) => {
+    try {
+      return await import(`../${checkerType}/locales/${language}.json`, { with: { type: 'json' } });
+    } catch {
+      return await import(`../${checkerType}/locales/en.json`, { with: { type: 'json' } });
+    }
+  };
+}


### PR DESCRIPTION
This PR fixes an issue discovered when upgrading SF to Angular 19 where using locales in SF other than 'en' would throw error: 'Module not found in bundle.'

The fix creates a function `createLocaleLoader` that tries the specified locale and falls back to 'en' on error.