### PR TITLE
Add support for commands in diagnostic providers

### DIFF
--- a/.changeset/cute-plums-work.md
+++ b/.changeset/cute-plums-work.md
@@ -1,0 +1,6 @@
+---
+'@sillsdev/lynx-punctuation-checker': minor
+'@sillsdev/lynx': minor
+---
+
+Add support for commands in diagnostic providers

--- a/README.md
+++ b/README.md
@@ -1,3 +1,282 @@
 # Lynx
 
-A library for providing AI capabilities to translation editing environments
+Lynx is a TypeScript library for adding diagnostic and formatting capabilities to translation editing environments. It provides a plugin-based architecture in which _providers_ check documents for issues, suggest fixes, and format text as users type. A _workspace_ orchestrates any number of providers and exposes a unified API to the host application.
+
+## Packages
+
+| Package                              | Description                                                     |
+| ------------------------------------ | --------------------------------------------------------------- |
+| `@sillsdev/lynx`                     | Core interfaces, `Workspace`, `DocumentManager`, `Localizer`    |
+| `@sillsdev/lynx-usfm`                | USFM document support                                           |
+| `@sillsdev/lynx-delta`               | [Quill Delta](https://quilljs.com/docs/delta/) document support |
+| `@sillsdev/lynx-punctuation-checker` | Built-in punctuation, quotation, and character checker          |
+| `@sillsdev/lynx-examples`            | Example providers and utilities                                 |
+
+Install the packages you need:
+
+```sh
+npm install @sillsdev/lynx
+npm install @sillsdev/lynx-usfm          # if using USFM documents
+npm install @sillsdev/lynx-delta         # if using Quill Delta documents
+npm install @sillsdev/lynx-punctuation-checker
+```
+
+## Core Concepts
+
+### Documents
+
+A `Document` is an in-memory representation of a text file, identified by a URI. For Scripture translation work, `ScriptureDocument` extends `Document` with a tree of typed nodes (books, chapters, verses, etc.) that providers can traverse.
+
+The `DocumentFactory` interface is responsible for creating and updating document instances from raw content. Choose the factory that matches your document format:
+
+- `UsfmDocumentFactory` — for USFM files
+- `DeltaDocumentFactory` / `ScriptureDeltaDocumentFactory` — for Quill Delta documents
+
+`EditFactory` is the companion interface providers use to produce text edits without being coupled to a specific document format. Its `createTextEdit(document, range, newText)` method returns the correct edit type for the document format in use. For Scripture documents, `ScriptureEditFactory` extends it with `createScriptureEdit(document, range, nodes)`, which constructs edits from Scripture node objects rather than raw strings. As with `DocumentFactory`, choose the implementation that matches your format:
+
+- `UsfmEditFactory` — for USFM files
+- `DeltaEditFactory` / `ScriptureDeltaEditFactory` — for Quill Delta documents
+
+For a full walkthrough of implementing support for a new format, see [Implementing a New Document Format](docs/new-document-format.md).
+
+### DocumentManager
+
+`DocumentManager` tracks the lifecycle of open documents and makes them available to providers via the `DocumentAccessor` interface. Notify it whenever the host application opens, modifies, or closes a document:
+
+```ts
+documentManager.fireOpened(uri, { format: 'usfm', version: 1, content: text });
+documentManager.fireChanged(uri, { contentChanges: [...], version: 2 });
+documentManager.fireClosed(uri);
+```
+
+### DocumentReader
+
+`DocumentReader` is the interface your application implements to connect `DocumentManager` to your document storage backend — whether that is the file system, a database, cloud storage, or any other source. Pass your implementation as the second argument to the `DocumentManager` constructor:
+
+```ts
+const documentManager = new DocumentManager(documentFactory, new MyDocumentReader());
+```
+
+The interface has two methods:
+
+- `keys()` — return the URIs of all documents available in the backend
+- `read(uri)` — return the raw content and metadata for a single document
+
+`DocumentManager` uses `DocumentReader` to enumerate all documents when `all()` is called, and to load document content on demand when a document is requested but not yet in memory. If no `DocumentReader` is provided, `DocumentManager` only has access to documents that have been explicitly opened via `fireOpened`.
+
+### DiagnosticProvider
+
+A `DiagnosticProvider` inspects documents and reports problems as `Diagnostic` values. It can also return `DiagnosticAction` values — quick-fix suggestions that the UI can offer to the user.
+
+### OnTypeFormattingProvider
+
+An `OnTypeFormattingProvider` reacts to characters typed by the user and returns `TextEdit` values to apply immediately. Common uses include autocorrecting quotation marks or inserting matching punctuation pairs.
+
+### Workspace
+
+`Workspace` is the central orchestrator. It holds all registered providers, aggregates their diagnostics, manages dismissed diagnostics, and delegates formatting requests. Most host applications interact only with `Workspace`.
+
+### Localizer
+
+`Localizer` is a thin wrapper around [i18next](https://www.i18next.com/) that providers use to produce localized diagnostic messages. Each provider registers its own translation namespace during `init()`.
+
+## Setting Up a Workspace
+
+The following example sets up a workspace with English punctuation checking for USFM documents.
+
+**1. Install dependencies**
+
+```sh
+npm install @sillsdev/lynx @sillsdev/lynx-usfm @sillsdev/lynx-punctuation-checker
+```
+
+**2. Create the workspace**
+
+```ts
+import { DocumentManager, Localizer, ScriptureDocument, Workspace } from '@sillsdev/lynx';
+import { UsfmDocumentFactory, UsfmEditFactory } from '@sillsdev/lynx-usfm';
+import { UsfmStylesheet } from '@sillsdev/machine/corpora';
+import { StandardRuleSets } from '@sillsdev/lynx-punctuation-checker';
+
+// Localization support
+const localizer = new Localizer();
+
+// USFM parsing
+const stylesheet = new UsfmStylesheet('usfm.sty');
+const documentFactory = new UsfmDocumentFactory(stylesheet);
+const editFactory = new UsfmEditFactory(stylesheet);
+
+// Document tracking
+const documentManager = new DocumentManager<ScriptureDocument>(documentFactory);
+
+// English punctuation rule set
+const ruleSet = StandardRuleSets.English;
+
+// Workspace with diagnostic and formatting providers
+const workspace = new Workspace({
+  localizer,
+  diagnosticProviders: [...ruleSet.createDiagnosticProviders(localizer, documentManager, editFactory)],
+  onTypeFormattingProviders: [...ruleSet.createOnTypeFormattingProviders(documentManager, editFactory)],
+});
+
+// Initialize before use
+await workspace.init();
+```
+
+`StandardRuleSets.English` creates four diagnostic providers — `AllowedCharacterChecker`, `QuotationChecker`, `PairedPunctuationChecker`, and `PunctuationContextChecker` — plus an on-type formatting provider for autocorrecting quotation marks.
+
+**3. Register additional providers**
+
+Pass all providers to the workspace constructor. The following example adds the example `VerseOrderDiagnosticProvider`:
+
+```ts
+import { VerseOrderDiagnosticProvider, SimpleQuoteFormattingProvider } from '@sillsdev/lynx-examples';
+
+const workspace = new Workspace({
+  localizer,
+  diagnosticProviders: [
+    ...ruleSet.createDiagnosticProviders(localizer, documentManager, editFactory),
+    new VerseOrderDiagnosticProvider(localizer, documentManager, editFactory),
+  ],
+  onTypeFormattingProviders: [
+    ...ruleSet.createOnTypeFormattingProviders(documentManager, editFactory),
+    new SimpleQuoteFormattingProvider(documentManager, editFactory),
+  ],
+});
+
+await workspace.init();
+```
+
+## Managing Documents
+
+Notify `DocumentManager` of document lifecycle events so providers always have up-to-date content:
+
+```ts
+// User opens a file
+await documentManager.fireOpened(uri, {
+  format: 'usfm',
+  version: 1,
+  content: rawText,
+});
+
+// User edits the file (incremental changes)
+await documentManager.fireChanged(uri, {
+  contentChanges: [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } }, text: 'Hello' }],
+  version: 2,
+});
+
+// User closes the file
+await documentManager.fireClosed(uri);
+```
+
+## Getting Diagnostics
+
+Call `workspace.getDiagnostics(uri)` to get all current diagnostics for a document from all registered providers. Dismissed diagnostics are automatically excluded.
+
+```ts
+const diagnostics = await workspace.getDiagnostics('file:///path/to/document.usfm');
+
+for (const diagnostic of diagnostics) {
+  console.log(
+    `[${diagnostic.source}] ${diagnostic.message}`,
+    `at line ${diagnostic.range.start.line}, char ${diagnostic.range.start.character}`,
+    `severity: ${diagnostic.severity}`, // 1=Error, 2=Warning, 3=Information, 4=Hint
+  );
+}
+```
+
+A `Diagnostic` has the following shape:
+
+```ts
+interface Diagnostic {
+  code: string | number; // Provider-specific issue code
+  source: string; // Provider id (e.g. 'quotation', 'verse-order')
+  range: Range; // Location in the document
+  severity: DiagnosticSeverity;
+  message: string; // Human-readable description
+  moreInfo?: string; // Extended explanation
+  data?: unknown; // Provider-specific payload
+  fingerprint?: string; // Stable identifier for dismissal
+}
+```
+
+### Reactive Diagnostics
+
+For push-based updates, subscribe to `workspace.diagnosticsChanged$`. It emits a combined `DiagnosticsChanged` event whenever any provider reports new results:
+
+```ts
+workspace.diagnosticsChanged$.subscribe(({ uri, version, diagnostics }) => {
+  // Update the UI with the new diagnostics for `uri`
+});
+```
+
+## Getting and Applying Fix Actions
+
+Each diagnostic may have one or more `DiagnosticAction` values the user can invoke:
+
+```ts
+const actions = await workspace.getDiagnosticActions(uri, diagnostic);
+
+for (const action of actions) {
+  console.log(action.title, action.isPreferred ? '(preferred)' : '');
+
+  if (action.edits != null) {
+    // Apply the text edits directly to the document
+    applyEdits(action.edits);
+  }
+
+  if (action.command != null) {
+    // Execute the action via the workspace
+    const changed = await workspace.executeDiagnosticActionCommand(action.command, uri, diagnostic);
+    if (changed) {
+      // The provider state changed; refresh diagnostics
+    }
+  }
+}
+```
+
+## On-Type Formatting
+
+Register the trigger characters with your editor, then call `workspace.getOnTypeEdits()` whenever the user types one of them:
+
+```ts
+// Get all characters that trigger formatting across all providers
+const triggerChars = workspace.getOnTypeTriggerCharacters();
+
+// When the user types a character
+async function onCharacterTyped(uri: string, position: Position, ch: string) {
+  if (triggerChars.includes(ch)) {
+    const edits = await workspace.getOnTypeEdits(uri, position, ch);
+    if (edits != null) {
+      applyEdits(edits);
+    }
+  }
+}
+```
+
+## Diagnostic Dismissal
+
+Diagnostics that include a `fingerprint` can be permanently dismissed. Dismissed diagnostics are filtered out of future `getDiagnostics()` and `diagnosticsChanged$` results.
+
+By default `Workspace` uses an in-memory store that does not persist across sessions. To persist dismissals, implement the `DiagnosticDismissalStore` interface. For a full walkthrough see [Implementing a Dismissal Store](docs/implementing-a-dismissal-store.md).
+
+It can be provided in the `Workspace` constructor or assigned afterward:
+
+```ts
+// Option 1: pass in the constructor
+const workspace = new Workspace({
+  localizer,
+  diagnosticProviders: [...],
+  diagnosticDismissalStore: new MyDismissalStore(),
+});
+
+// Option 2: assign before or after calling workspace.init()
+workspace.diagnosticDismissalStore = new MyDismissalStore();
+
+// Dismiss a diagnostic (diagnostic.fingerprint must not be null)
+await workspace.dismissDiagnostic(uri, diagnostic);
+```
+
+## Implementing a Custom Diagnostic Provider
+
+To check for custom issues, implement the `DiagnosticProvider` interface. For a full walkthrough covering the interface contract, reactive diagnostics, `Diagnostic` and `DiagnosticAction` types, localization, commands, and the refresh cycle, see [Implementing a Custom Diagnostic Provider](docs/implementing-a-diagnostic-provider.md).

--- a/docs/implementing-a-diagnostic-provider.md
+++ b/docs/implementing-a-diagnostic-provider.md
@@ -1,0 +1,344 @@
+# Implementing a Custom Diagnostic Provider
+
+A `DiagnosticProvider` inspects documents and reports problems as `Diagnostic` values. It can also return `DiagnosticAction` values — quick-fix suggestions that the host UI can offer to the user.
+
+## The `DiagnosticProvider<T>` Interface
+
+```ts
+import { DiagnosticProvider } from '@sillsdev/lynx';
+
+class MyProvider implements DiagnosticProvider<TextEdit> { ... }
+```
+
+The type parameter `T` is the edit type produced by `getDiagnosticActions`. For most providers this is `TextEdit`. If your document format uses a different edit type (e.g. a Quill Delta op), use that type instead — it must match the `EditFactory` in use.
+
+The interface has the following members:
+
+| Member                                     | Description                                                                                                                                                                             |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                                       | Unique string identifier for the provider. Used as the `source` field on every emitted `Diagnostic` and as the namespace for provider-specific commands.                                |
+| `diagnosticsChanged$`                      | Observable that emits a `DiagnosticsChanged` event whenever this provider's results change for a document.                                                                              |
+| `commands`                                 | Set of command strings this provider handles. Declare all commands here; `Workspace` will route `executeDiagnosticActionCommand` calls to `executeCommand` for any command in this set. |
+| `init()`                                   | Called once by `Workspace.init()`. Register i18n namespaces and perform any async initialization here.                                                                                  |
+| `getDiagnostics(uri)`                      | Return all current diagnostics for the document at `uri`. Called on demand by `Workspace.getDiagnostics()`.                                                                             |
+| `getDiagnosticActions(uri, diagnostic)`    | Return fix actions for a single diagnostic.                                                                                                                                             |
+| `executeCommand(command, uri, diagnostic)` | Execute a provider command. Return `true` if provider state changed; `Workspace` will call `refresh()` automatically.                                                                   |
+| `refresh(uri)`                             | Called by `Workspace` after a dismissal or a command execution. Trigger re-validation of the document.                                                                                  |
+
+---
+
+## Setting Up `diagnosticsChanged$`
+
+`diagnosticsChanged$` is the push channel `Workspace` subscribes to for reactive diagnostic updates. Lynx provides two helper functions to build it.
+
+### `activeDiagnosticsChanged$`
+
+Use this for providers that only need to validate currently-open documents:
+
+```ts
+import { activeDiagnosticsChanged$ } from '@sillsdev/lynx';
+import { Subject } from 'rxjs';
+
+private readonly refreshSubject = new Subject<string>();
+
+constructor(private readonly documents: DocumentAccessor<MyDocument>) {
+  this.diagnosticsChanged$ = activeDiagnosticsChanged$(
+    documents,
+    (doc) => this.validate(doc),
+    this.refreshSubject,
+  );
+}
+```
+
+`activeDiagnosticsChanged$` subscribes to `documents.opened$`, `documents.changed$`, and `documents.closed$`. When a document closes it emits an empty diagnostics array for that URI. The optional `refreshSubject` parameter lets you trigger re-validation at any time by calling `refreshSubject.next(uri)`.
+
+### `allDiagnosticsChanged$`
+
+Use this when your provider needs to validate documents that are not currently open — for example, providers that perform cross-document consistency checks, or that load documents from a `DocumentReader`:
+
+```ts
+import { allDiagnosticsChanged$ } from '@sillsdev/lynx';
+
+this.diagnosticsChanged$ = allDiagnosticsChanged$(documents, (doc) => this.validate(doc), this.refreshSubject);
+```
+
+`allDiagnosticsChanged$` additionally handles `documents.created$`, `documents.deleted$`, and `documents.reset$`. It also takes an initial snapshot of all documents when first subscribed, using a buffered connectable to avoid losing events that arrive during the snapshot pass.
+
+**Rule of thumb:** use `activeDiagnosticsChanged$` unless you have a specific reason to run diagnostics on closed or unloaded documents.
+
+---
+
+## The `Diagnostic` Type
+
+```ts
+interface Diagnostic {
+  code: string | number; // Provider-specific issue code
+  source: string; // Must equal this.id
+  range: Range; // Location in the document
+  severity: DiagnosticSeverity;
+  message: string; // Human-readable description
+  moreInfo?: string; // Extended explanation or documentation link
+  data?: unknown; // Arbitrary provider-specific payload
+  fingerprint?: string; // Stable identifier for dismissal
+}
+```
+
+### `DiagnosticSeverity`
+
+| Value | Constant                         |
+| ----- | -------------------------------- |
+| `1`   | `DiagnosticSeverity.Error`       |
+| `2`   | `DiagnosticSeverity.Warning`     |
+| `3`   | `DiagnosticSeverity.Information` |
+| `4`   | `DiagnosticSeverity.Hint`        |
+
+### `source`
+
+The `source` field on every diagnostic **must** equal `this.id`. `Workspace` uses this to route dismissals and command executions back to the correct provider.
+
+### `data`
+
+Use `data` to carry provider-specific information that `getDiagnosticActions` will need when constructing fix actions. For example, a missing-verse provider might store the verse reference in `data` so that `getDiagnosticActions` can build an insertion edit without re-parsing the document.
+
+### `fingerprint`
+
+Set `fingerprint` on any diagnostic that should be dismissible. A fingerprint is a stable string that uniquely identifies a particular issue within a document — it should not change when unrelated lines are edited.
+
+A good fingerprint combines the issue code and enough context to identify the specific occurrence:
+
+```ts
+// e.g. "2|GEN 1:3" — code 2, missing verse GEN 1:3
+fingerprint: `${code}|${verseRef}`,
+```
+
+Fingerprints are stored by `DiagnosticDismissalStore` and matched against future diagnostics from the same provider and document. Diagnostics without a fingerprint cannot be dismissed.
+
+---
+
+## The `DiagnosticAction<T>` Type
+
+```ts
+interface DiagnosticAction<T> {
+  title: string; // Display text shown in the UI
+  diagnostic: Diagnostic;
+  isPreferred?: boolean; // Hint to the UI to highlight this action
+  edits?: T[]; // Text edits to apply directly
+  command?: string; // Provider command to execute instead
+}
+```
+
+An action may carry either `edits` or `command` — not both.
+
+### Edit-based actions
+
+Return `edits` when the fix can be expressed entirely as text replacements. The host application applies them directly without calling back into the workspace:
+
+```ts
+{
+  title: 'Insert missing verse',
+  isPreferred: true,
+  diagnostic,
+  edits: editFactory.createTextEdit(document, insertionRange, verseText),
+}
+```
+
+For Scripture document formats, use `ScriptureEditFactory.createScriptureEdit` to build edits from Scripture node objects:
+
+```ts
+{
+  title: 'Insert missing verse',
+  isPreferred: true,
+  diagnostic,
+  edits: scriptureEditFactory.createScriptureEdit(document, insertionRange, verseNode),
+}
+```
+
+### Command-based actions
+
+Return a `command` string when the action needs to modify provider state rather than (or in addition to) the document. The host calls `workspace.executeDiagnosticActionCommand(action.command, uri, diagnostic)`, which routes to `executeCommand` on the owning provider:
+
+```ts
+{
+  title: 'Exclude this verse from checking',
+  diagnostic,
+  command: 'excludeVerse',
+}
+```
+
+The command string must appear in `this.commands`. `Workspace` only routes diagnostic action commands declared in this set; attempting to execute a command not listed here will result in an error.
+
+---
+
+## `executeCommand` and the Refresh Cycle
+
+`executeCommand` receives the command name, the URI of the document it was invoked on, and the original `Diagnostic`:
+
+```ts
+executeCommand(command: string, uri: string, diagnostic: Diagnostic): Promise<boolean> {
+  if (command === 'excludeVerse') {
+    this.excludedVerses.add(diagnostic.data as string);
+    return Promise.resolve(true);  // state changed
+  }
+  return Promise.resolve(false);
+}
+```
+
+Return `true` if provider state changed in a way that would affect diagnostics. `Workspace` will then call `refresh(uri)` automatically. Return `false` if no re-evaluation is needed.
+
+`refresh` should push the URI through the `refreshSubject` so that `diagnosticsChanged$` re-validates the document:
+
+```ts
+refresh(uri: string): Promise<void> {
+  this.refreshSubject.next(uri);
+  return Promise.resolve();
+}
+```
+
+---
+
+## Localization
+
+Providers use `Localizer` (a thin wrapper around [i18next](https://www.i18next.com/)) for human-readable diagnostic messages. Register your translation namespace in `init()`:
+
+```ts
+init(): Promise<void> {
+  this.localizer.addNamespace(
+    'myProvider',
+    (language) => import(`./locales/${language}/my-provider.json`, { with: { type: 'json' } }),
+  );
+  return Promise.resolve();
+}
+```
+
+Then use `this.localizer.t('myProvider:someKey')` when building `message` strings inside `validate()`. Translations are loaded lazily when the active language is first requested.
+
+---
+
+## Full Example
+
+The following is a complete, annotated provider skeleton. It validates plain text documents and reports issues with two codes.
+
+```ts
+import {
+  activeDiagnosticsChanged$,
+  Diagnostic,
+  DiagnosticAction,
+  DiagnosticProvider,
+  DiagnosticsChanged,
+  DiagnosticSeverity,
+  DocumentAccessor,
+  Localizer,
+  TextDocument,
+  TextEdit,
+} from '@sillsdev/lynx';
+import { Observable, Subject } from 'rxjs';
+
+export class MyDiagnosticProvider implements DiagnosticProvider<TextEdit> {
+  // Unique identifier — used as the `source` field on every diagnostic
+  // and as the routing key for commands declared below.
+  public readonly id = 'my-provider';
+
+  // All command strings this provider handles. Workspace routes
+  // executeDiagnosticActionCommand() calls here for any string in this set.
+  public readonly commands = new Set<string>(['ignoreIssue']);
+
+  // Push channel for reactive diagnostics. activeDiagnosticsChanged$
+  // re-validates each time a document opens, changes, or closes,
+  // and whenever refreshSubject emits a URI.
+  public readonly diagnosticsChanged$: Observable<DiagnosticsChanged>;
+
+  private readonly refreshSubject = new Subject<string>();
+
+  // Track which issues the user has chosen to ignore
+  private readonly ignoredIssues = new Set<string>();
+
+  constructor(
+    private readonly localizer: Localizer,
+    private readonly documents: DocumentAccessor<TextDocument>,
+    private readonly editFactory: EditFactory<TextDocument, TextEdit>,
+  ) {
+    this.diagnosticsChanged$ = activeDiagnosticsChanged$(
+      documents,
+      (doc) => Promise.resolve(this.validate(doc)),
+      this.refreshSubject,
+    );
+  }
+
+  // Called once by Workspace.init(). Register i18n namespaces here.
+  init(): Promise<void> {
+    this.localizer.addNamespace(
+      'myProvider',
+      (language) => import(`./locales/${language}/my-provider.json`, { with: { type: 'json' } }),
+    );
+    return Promise.resolve();
+  }
+
+  // Return all current diagnostics for the document at `uri`.
+  async getDiagnostics(uri: string): Promise<Diagnostic[]> {
+    const doc = await this.documents.get(uri);
+    if (doc == null) return [];
+    return this.validate(doc);
+  }
+
+  // Return fix actions for a single diagnostic.
+  async getDiagnosticActions(uri: string, diagnostic: Diagnostic): Promise<DiagnosticAction<TextEdit>[]> {
+    const doc = await this.documents.get(uri);
+    if (doc == null) return [];
+
+    if (diagnostic.code === 1) {
+      // Provide a direct text edit fix
+      return [
+        {
+          title: this.localizer.t('myProvider:fixIssue'),
+          isPreferred: true,
+          diagnostic,
+          edits: this.editFactory.createTextEdit(doc, diagnostic.range, correctedText),
+        },
+        {
+          title: this.localizer.t('myProvider:ignoreIssue'),
+          diagnostic,
+          command: 'ignoreIssue',
+        },
+      ];
+    }
+    return [];
+  }
+
+  // Execute a command registered in `this.commands`.
+  // Return true if provider state changed; Workspace will call refresh().
+  executeCommand(command: string, _uri: string, diagnostic: Diagnostic): Promise<boolean> {
+    if (command === 'ignoreIssue' && diagnostic.fingerprint != null) {
+      this.ignoredIssues.add(diagnostic.fingerprint);
+      return Promise.resolve(true); // state changed — triggers refresh
+    }
+    return Promise.resolve(false);
+  }
+
+  // Called by Workspace after a dismissal or command execution.
+  // Push the URI through refreshSubject to trigger re-validation.
+  refresh(uri: string): Promise<void> {
+    this.refreshSubject.next(uri);
+    return Promise.resolve();
+  }
+
+  private validate(doc: TextDocument): Diagnostic[] {
+    const text = doc.getText();
+    const diagnostics: Diagnostic[] = [];
+
+    // ... scan text and build Diagnostic objects ...
+
+    return diagnostics.filter((d) => d.fingerprint == null || !this.ignoredIssues.has(d.fingerprint));
+  }
+}
+```
+
+---
+
+## Important Rules
+
+- The `source` field on every emitted `Diagnostic` must equal `this.id`.
+- Every command string returned in a `DiagnosticAction.command` must appear in `this.commands`.
+- Set `fingerprint` on diagnostics that should be dismissible. A fingerprint must be stable across edits to unrelated parts of the document.
+- Return `true` from `executeCommand` when provider state changed. `Workspace` handles calling `refresh()`.
+- Call `this.refreshSubject.next(uri)` inside `refresh()` to re-evaluate the document via `diagnosticsChanged$`.
+- Do not push to `refreshSubject` from within `getDiagnostics` — that method is a pull channel and must not trigger side effects.

--- a/docs/implementing-a-dismissal-store.md
+++ b/docs/implementing-a-dismissal-store.md
@@ -1,0 +1,163 @@
+# Implementing a DiagnosticDismissalStore
+
+`DiagnosticDismissalStore` is the interface `Workspace` uses to record which diagnostics a user has permanently dismissed. When a diagnostic is dismissed its fingerprint is stored, and `Workspace` filters it out of all future `getDiagnostics()` and `diagnosticsChanged$` results for that document.
+
+By default `Workspace` uses `InMemoryDiagnosticDismissalStore`, which holds dismissals only for the duration of the current process. Implement this interface when you need dismissals to survive process restarts.
+
+## The Interface
+
+```ts
+import { Diagnostic, DiagnosticDismissalStore } from '@sillsdev/lynx';
+
+export class MyDismissalStore implements DiagnosticDismissalStore {
+  getDismissals(uri: string, source: string): Promise<Set<string> | undefined> { ... }
+  addDismissal(uri: string, diagnostic: Diagnostic): Promise<void> { ... }
+  removeDismissals(uri: string, source: string, fingerprints: Set<string>): Promise<void> { ... }
+}
+```
+
+## Method Contracts
+
+### `getDismissals(uri, source)`
+
+Called by `Workspace` every time it filters a provider's diagnostics — on both pull (`getDiagnostics()`) and push (`diagnosticsChanged$`) paths.
+
+- Return `undefined` if no dismissals have been recorded for this `uri`+`source` combination. `Workspace` short-circuits on `undefined` and yields all diagnostics without filtering.
+- Return a `Set<string>` of dismissed fingerprints otherwise.
+
+### `addDismissal(uri, diagnostic)`
+
+Called by `Workspace.dismissDiagnostic()` when the user dismisses a diagnostic.
+
+- Store the dismissal based on `diagnostic.fingerprint`. Diagnostics without a fingerprint are not dismissible and can be ignored.
+
+### `removeDismissals(uri, source, fingerprints)`
+
+Called by `Workspace` during filtering when dismissed fingerprints no longer appear in the provider's current diagnostic output — meaning the underlying issue was fixed and the dismissal record is stale.
+
+- Remove each dismissal based on the fingerprints in the supplied `Set` from the store. Silently ignore any that are not present.
+
+---
+
+## Implementation Guidance
+
+### Cache dismissals in memory
+
+`getDismissals` is called on every diagnostic filtering pass, which happens frequently. Implementations should maintain an in-memory cache of the full dismissal set, loading it lazily from the backing store on the first method call. Subsequent calls read from the cache without any expensive I/O calls.
+
+`addDismissal` and `removeDismissals` update the cache immediately, so the next `getDismissals` call reflects the change without waiting for the backing store to be written.
+
+### Use fire-and-forget writes
+
+Writes to the backing store should not block the caller. After updating the cache, trigger the persist operation in the background and return. Serializing concurrent writes (e.g. queuing them onto a shared promise) avoids write conflicts without making callers wait.
+
+---
+
+## Example Implementation
+
+The following example persists dismissals to a JSON file. It demonstrates the two key patterns from the guidance above: a lazily-initialized in-memory cache and a fire-and-forget write queue.
+
+```ts
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { Diagnostic, DiagnosticDismissalStore } from '@sillsdev/lynx';
+
+// On-disk format: { [uri]: { [source]: string[] } }
+type DismissalData = Record<string, Record<string, string[]>>;
+
+export class JsonFileDismissalStore implements DiagnosticDismissalStore {
+  // In-memory cache — the source of truth for all reads after initialization.
+  private data: DismissalData = {};
+  private initialized = false;
+
+  // Serializes concurrent writes so they don't clobber each other.
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly filePath: string) {}
+
+  // Loads data from disk on the first call, then returns immediately on
+  // subsequent calls.
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      this.data = JSON.parse(content) as DismissalData;
+    } catch (e: unknown) {
+      // ENOENT just means no dismissals have been saved yet — that's fine.
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+    }
+  }
+
+  async getDismissals(uri: string, source: string): Promise<Set<string> | undefined> {
+    await this.ensureInitialized();
+    if (uri in this.data && source in this.data[uri]) {
+      return new Set(this.data[uri][source]);
+    }
+    return undefined;
+  }
+
+  async addDismissal(uri: string, diagnostic: Diagnostic): Promise<void> {
+    await this.ensureInitialized();
+    if (diagnostic.fingerprint == null) return;
+
+    this.data[uri] ??= {};
+    this.data[uri][diagnostic.source] ??= [];
+
+    const existing = this.data[uri][diagnostic.source];
+    if (!existing.includes(diagnostic.fingerprint)) {
+      existing.push(diagnostic.fingerprint);
+    }
+
+    this.enqueueWrite();
+  }
+
+  async removeDismissals(uri: string, source: string, fingerprints: Set<string>): Promise<void> {
+    await this.ensureInitialized();
+    if (!(uri in this.data) || !(source in this.data[uri])) return;
+
+    this.data[uri][source] = this.data[uri][source].filter((f) => !fingerprints.has(f));
+
+    // Clean up empty entries so the file doesn't grow indefinitely.
+    if (this.data[uri][source].length === 0) delete this.data[uri][source];
+    if (Object.keys(this.data[uri]).length === 0) delete this.data[uri];
+
+    this.enqueueWrite();
+  }
+
+  // Chains the next persist() call onto the end of writeQueue so writes are
+  // serialized without blocking the caller.
+  private enqueueWrite(): void {
+    this.writeQueue = this.writeQueue
+      .then(() => this.persist())
+      .catch(() => {
+        /* swallow write errors */
+      });
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(this.data, null, 2));
+  }
+}
+```
+
+---
+
+## Registering the Store
+
+Pass the store in the `Workspace` constructor or assign it to the property:
+
+```ts
+// Option 1: constructor
+const workspace = new Workspace({
+  localizer,
+  diagnosticProviders: [...],
+  diagnosticDismissalStore: new MyDismissalStore(),
+});
+
+// Option 2: property assignment (before or after init())
+workspace.diagnosticDismissalStore = new MyDismissalStore();
+```

--- a/docs/new-document-format.md
+++ b/docs/new-document-format.md
@@ -1,0 +1,328 @@
+# Implementing a New Document Format
+
+A document format implementation gives Lynx providers access to documents in your application. There are three paths depending on how content is stored and whether your format has semantic Scripture structure:
+
+- **Plain text format** — for string-based formats with no chapter/verse/paragraph structure. Providers receive the document as plain text.
+- **Scripture format** — for string-based formats that map to a Scripture node tree (books, chapters, verses, paragraphs, etc.). Providers can traverse and manipulate the structure directly.
+- **Custom format** — for formats whose content is not a plain string (e.g. a parsed object model or binary representation). Implement the `Document` interface directly and define custom content and change types.
+
+All three paths require three classes: a **Document**, a **DocumentFactory**, and an **EditFactory**. Scripture formats additionally require a parser and a serializer, which are covered alongside the DocumentFactory and EditFactory classes respectively.
+
+## Plain Text Format
+
+### Document class
+
+Extend `TextDocument` from `@sillsdev/lynx`. `TextDocument` handles line/offset tracking and incremental text updates, so very little additional code is needed.
+
+```ts
+import { TextDocument } from '@sillsdev/lynx';
+
+export class MyDocument extends TextDocument {
+  // TextDocument already implements getText(), positionAt(), and update().
+  // Add any format-specific accessors here if needed.
+}
+```
+
+### DocumentFactory class
+
+Implement `DocumentFactory<MyDocument>`. The factory is responsible for constructing new document instances and applying incremental changes.
+
+```ts
+import { DocumentChanges, DocumentData, DocumentFactory, TextDocumentChange } from '@sillsdev/lynx';
+import { MyDocument } from './my-document';
+
+export class MyDocumentFactory implements DocumentFactory<MyDocument> {
+  create(uri: string, data: DocumentData): MyDocument {
+    return new MyDocument(uri, data.format, data.version, data.content);
+  }
+
+  update(document: MyDocument, changes: DocumentChanges<TextDocumentChange>): MyDocument {
+    document.update(changes.contentChanges, changes.version);
+    return document;
+  }
+}
+```
+
+`DocumentData` carries the raw `content` string, `format` identifier, and `version` number. `DocumentChanges` carries an array of range-based text replacements and the new `version`.
+
+### EditFactory class
+
+Extend `TextEditFactory<MyDocument>`. The base class already implements `createTextEdit()` by returning a plain `TextEdit`, so no additional code is required for a text-only format.
+
+```ts
+import { TextEditFactory } from '@sillsdev/lynx';
+import { MyDocument } from './my-document';
+
+export class MyEditFactory extends TextEditFactory<MyDocument> {}
+```
+
+### Putting it together
+
+```ts
+import { DocumentManager } from '@sillsdev/lynx';
+import { MyDocumentFactory } from './my-document-factory';
+import { MyEditFactory } from './my-edit-factory';
+
+const documentFactory = new MyDocumentFactory();
+const editFactory = new MyEditFactory();
+const documentManager = new DocumentManager(documentFactory);
+```
+
+Pass `documentManager` and `editFactory` to any provider constructors that require them.
+
+---
+
+## Scripture Format
+
+A Scripture format implementation exposes the document as a tree of typed nodes — `ScriptureBook`, `ScriptureParagraph`, `ScriptureChapter`, `ScriptureVerse`, `ScriptureText`, and others — that providers traverse and query. This requires two additional responsibilities beyond the plain text path: a **parser** that builds the node tree from raw content, and a **serializer** that converts nodes back to raw format text.
+
+### Document class
+
+Extend `ScriptureTextDocument`, which combines `TextDocument` with the `ScriptureDocument` node tree interface via `ScriptureDocumentMixin`.
+
+The constructor must parse the raw content into a Scripture node tree and append the top-level nodes as children of the document. Every node must have an accurate `range` value so that providers can locate issues in the source text.
+
+Override `update()` to re-parse the affected region after incremental changes.
+
+```ts
+import { ScriptureNode, ScriptureTextDocument, TextDocumentChange } from '@sillsdev/lynx';
+
+export class MyScriptureDocument extends ScriptureTextDocument {
+  constructor(uri: string, format: string, version: number, content: string) {
+    super(uri, format, version, content);
+    for (const node of parseMyFormat(content)) {
+      this.appendChild(node);
+    }
+  }
+
+  update(changes: TextDocumentChange[], version: number): void {
+    super.update(changes, version);
+    this.clearChildren();
+    for (const node of parseMyFormat(this.getText())) {
+      this.appendChild(node);
+    }
+  }
+}
+```
+
+If parsing is expensive, consider re-parsing only the lines affected by each change rather than the full document on every update.
+
+If your content is not a plain string, `ScriptureTextDocument` is not appropriate. Instead, apply `ScriptureDocumentMixin` directly to your own Document base class. `ScriptureTextDocument` itself is just `ScriptureDocumentMixin(TextDocument)`, so the mixin works with any class that implements `Document`:
+
+```ts
+import { ScriptureDocumentMixin } from '@sillsdev/lynx';
+import { MyDocument } from './my-document';
+
+export class MyScriptureDocument extends ScriptureDocumentMixin(MyDocument) {
+  constructor(uri: string, format: string, version: number, content: MyContent) {
+    super(uri, format, version, content);
+    for (const node of parseMyFormat(content)) {
+      this.appendChild(node);
+    }
+  }
+
+  update(changes: MyChange[], version: number): void {
+    super.update(changes, version);
+    this.clearChildren();
+    for (const node of parseMyFormat(this.getContent())) {
+      this.appendChild(node);
+    }
+  }
+}
+```
+
+### DocumentFactory class
+
+The shape is identical to the plain text case. The factory's `create()` method constructs a new document, which in its constructor calls the parser to build the initial Scripture node tree.
+
+```ts
+import { DocumentChanges, DocumentData, DocumentFactory, TextDocumentChange } from '@sillsdev/lynx';
+import { MyScriptureDocument } from './my-scripture-document';
+
+export class MyDocumentFactory implements DocumentFactory<MyScriptureDocument> {
+  create(uri: string, data: DocumentData): MyScriptureDocument {
+    return new MyScriptureDocument(uri, data.format, data.version, data.content);
+  }
+
+  update(document: MyScriptureDocument, changes: DocumentChanges<TextDocumentChange>): MyScriptureDocument {
+    document.update(changes.contentChanges, changes.version);
+    return document;
+  }
+}
+```
+
+The parser itself typically lives as a private helper of the document class. Key requirements:
+
+- Return instances of the core node types: `ScriptureBook`, `ScriptureParagraph`, `ScriptureChapter`, `ScriptureVerse`, `ScriptureCharacterStyle`, `ScriptureNote`, `ScriptureText`, etc.
+- Set the `range` property on every node. Ranges must use line/character positions consistent with the values `positionAt()` would return for those offsets.
+- Build the parent/child hierarchy by constructing container nodes first, then appending leaf and child nodes to them.
+
+```ts
+import {
+  ScriptureBook,
+  ScriptureChapter,
+  ScriptureNode,
+  ScriptureParagraph,
+  ScriptureText,
+  ScriptureVerse,
+} from '@sillsdev/lynx';
+
+function parseMyFormat(content: string): ScriptureNode[] {
+  const nodes: ScriptureNode[] = [];
+  // ... walk the content and build nodes ...
+  return nodes;
+}
+```
+
+### EditFactory class
+
+Extend `ScriptureTextEditFactory<MyScriptureDocument>`, which inherits `createTextEdit()` from `TextEditFactory` and adds the abstract `createScriptureEdit()` method. Implement `createScriptureEdit()` by delegating to a serializer that converts the given nodes back to raw format text.
+
+```ts
+import { Range, ScriptureDocument, ScriptureNode, ScriptureTextEditFactory, TextEdit } from '@sillsdev/lynx';
+import { MyScriptureDocument } from './my-scripture-document';
+
+export class MyEditFactory extends ScriptureTextEditFactory<MyScriptureDocument> {
+  createScriptureEdit(document: ScriptureDocument, range: Range, nodes: ScriptureNode[] | ScriptureNode): TextEdit[] {
+    const nodeArray = Array.isArray(nodes) ? nodes : [nodes];
+    return [{ range, newText: serializeMyFormat(nodeArray) }];
+  }
+}
+```
+
+The serializer typically lives as a private helper of the edit factory:
+
+```ts
+function serializeMyFormat(nodes: ScriptureNode[]): string {
+  return nodes.map(serializeNode).join('');
+}
+
+function serializeNode(node: ScriptureNode): string {
+  // ... format-specific serialization per node type ...
+}
+```
+
+---
+
+## Custom Format
+
+Use this path when your content is not a plain string — for example, a pre-parsed object model, a binary format, or a structured representation like Quill Delta. You implement the `Document` interface directly and use the generic type parameters on `DocumentFactory` and `EditFactory` to carry your custom content and change types through to providers.
+
+### Document class
+
+Implement the `Document` interface from `@sillsdev/lynx`:
+
+```ts
+import { Document, Position } from '@sillsdev/lynx';
+
+export class MyDocument implements Document {
+  readonly uri: string;
+  readonly format: string;
+  version: number;
+
+  private content: MyContent;
+
+  constructor(uri: string, format: string, version: number, content: MyContent) {
+    this.uri = uri;
+    this.format = format;
+    this.version = version;
+    this.content = content;
+  }
+
+  getText(): string {
+    // Return a plain text representation of the document.
+    // Providers use this for text-based diagnostics and range calculations.
+    return convertToPlainText(this.content);
+  }
+
+  positionAt(offset: number): Position {
+    // Convert a character offset in getText() to a line/character Position.
+    const text = this.getText();
+    let line = 0;
+    let character = 0;
+    for (let i = 0; i < offset && i < text.length; i++) {
+      if (text[i] === '\n') {
+        line++;
+        character = 0;
+      } else {
+        character++;
+      }
+    }
+    return { line, character };
+  }
+
+  update(changes: MyChange[], version: number): void {
+    // Apply each change to this.content in order, then update the version.
+    for (const change of changes) {
+      this.content = applyChange(this.content, change);
+    }
+    this.version = version;
+  }
+}
+```
+
+### DocumentFactory class
+
+`DocumentFactory` has three generic parameters: `DocumentFactory<TDoc, TChange, TContent>`. Use them to specify your document class, your change type, and your content type. This allows `DocumentManager.fireOpened` and `fireChanged` to accept your custom types.
+
+```ts
+import { DocumentChanges, DocumentData, DocumentFactory } from '@sillsdev/lynx';
+import { MyDocument } from './my-document';
+
+export class MyDocumentFactory implements DocumentFactory<MyDocument, MyChange, MyContent> {
+  create(uri: string, data: DocumentData<MyContent>): MyDocument {
+    return new MyDocument(uri, data.format, data.version, data.content);
+  }
+
+  update(document: MyDocument, changes: DocumentChanges<MyChange>): MyDocument {
+    document.update(changes.contentChanges, changes.version);
+    return document;
+  }
+}
+```
+
+### EditFactory class
+
+`EditFactory` has two generic parameters: `EditFactory<TDoc, TEdit>`. If your format uses a custom edit type instead of `TextEdit`, specify it here.
+
+```ts
+import { EditFactory, Range } from '@sillsdev/lynx';
+import { MyDocument } from './my-document';
+
+export class MyEditFactory implements EditFactory<MyDocument, MyEdit> {
+  createTextEdit(document: MyDocument, range: Range, newText: string): MyEdit[] {
+    // Construct and return the format-specific edit operation.
+    return [buildEdit(document, range, newText)];
+  }
+}
+```
+
+---
+
+## Packaging
+
+Package your format implementation as a standalone npm package. Follow the `@sillsdev/lynx-<format>` naming convention used by the built-in packages.
+
+The file layout below assumes the package lives inside the Lynx monorepo under `packages/`. If your package is in a separate repository, any standard npm package layout works.
+
+Recommended file layout:
+
+```
+packages/
+  my-format/
+    src/
+      my-document.ts
+      my-document-factory.ts
+      my-edit-factory.ts
+      index.ts
+    package.json
+    tsconfig.json
+```
+
+`index.ts` should export exactly the document class, document factory, and edit factory:
+
+```ts
+export { MyDocument } from './my-document';
+export { MyDocumentFactory } from './my-document-factory';
+export { MyEditFactory } from './my-edit-factory';
+```

--- a/packages/core/src/diagnostic/diagnostic-action.ts
+++ b/packages/core/src/diagnostic/diagnostic-action.ts
@@ -1,9 +1,10 @@
 import { TextEdit } from '../common/text-edit';
 import { Diagnostic } from './diagnostic';
 
-export interface DiagnosticFix<T = TextEdit> {
+export interface DiagnosticAction<T = TextEdit> {
   title: string;
   diagnostic: Diagnostic;
   isPreferred?: boolean;
-  edits: T[];
+  edits?: T[];
+  command?: string;
 }

--- a/packages/core/src/diagnostic/diagnostic-provider.ts
+++ b/packages/core/src/diagnostic/diagnostic-provider.ts
@@ -18,7 +18,7 @@ import { TextEdit } from '../common/text-edit';
 import { Document } from '../document/document';
 import { DocumentAccessor } from '../document/document-accessor';
 import { Diagnostic } from './diagnostic';
-import { DiagnosticFix } from './diagnostic-fix';
+import { DiagnosticAction } from './diagnostic-action';
 
 export interface DiagnosticsChanged {
   uri: string;
@@ -29,10 +29,12 @@ export interface DiagnosticsChanged {
 export interface DiagnosticProvider<T = TextEdit> {
   readonly id: string;
   readonly diagnosticsChanged$: Observable<DiagnosticsChanged>;
+  readonly commands: ReadonlySet<string>;
   init(): Promise<void>;
   getDiagnostics(uri: string): Promise<Diagnostic[]>;
-  getDiagnosticFixes(uri: string, diagnostic: Diagnostic): Promise<DiagnosticFix<T>[]>;
+  getDiagnosticActions(uri: string, diagnostic: Diagnostic): Promise<DiagnosticAction<T>[]>;
   refresh(uri: string): Promise<void>;
+  executeCommand(command: string, uri: string, diagnostic: Diagnostic): Promise<boolean>;
 }
 
 export function activeDiagnosticsChanged$<T extends Document>(

--- a/packages/core/src/diagnostic/index.ts
+++ b/packages/core/src/diagnostic/index.ts
@@ -1,7 +1,7 @@
 export type { Diagnostic } from './diagnostic';
 export { DiagnosticSeverity } from './diagnostic';
+export type { DiagnosticAction } from './diagnostic-action';
 export type { DiagnosticDismissalStore } from './diagnostic-dismissal-store';
 export { InMemoryDiagnosticDismissalStore } from './diagnostic-dismissal-store';
-export type { DiagnosticFix } from './diagnostic-fix';
 export type { DiagnosticProvider, DiagnosticsChanged } from './diagnostic-provider';
 export { activeDiagnosticsChanged$, allDiagnosticsChanged$ } from './diagnostic-provider';

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -101,13 +101,14 @@ export class Workspace<T = TextEdit> {
     if (diagnostic.fingerprint == null) {
       throw new Error('Cannot dismiss a diagnostic without a fingerprint.');
     }
-    await this.diagnosticDismissalStore.addDismissal(uri, diagnostic);
 
     // Trigger a refresh on the provider that owns this diagnostic
     const provider = this.diagnosticProviders.get(diagnostic.source);
     if (provider == null) {
       throw new Error(`No provider found for diagnostic source ${diagnostic.source}.`);
     }
+
+    await this.diagnosticDismissalStore.addDismissal(uri, diagnostic);
     await provider.refresh(uri);
     return true;
   }

--- a/packages/examples/src/locales/en/verse-order.json
+++ b/packages/examples/src/locales/en/verse-order.json
@@ -2,7 +2,8 @@
   "missingVerse": {
     "description": "Verse {{verse}} is missing from chapter {{chapter}}. Insert the missing verse to fix.",
     "moreInfo": "A chapter should contain verse markers for all verses. This may be a typo or a missing verse. Please insert the missing verse to fix this issue.",
-    "fixTitle": "Insert missing verse"
+    "fixTitle": "Insert missing verse",
+    "excludeFixTitle": "Exclude {{verseRef}} from versification"
   },
   "verseOutOfOrder": {
     "description": "Verse {{verse}} occurs out of order in chapter {{chapter}}.",

--- a/packages/examples/src/locales/es/verse-order.json
+++ b/packages/examples/src/locales/es/verse-order.json
@@ -2,7 +2,8 @@
   "missingVerse": {
     "description": "Falta el versículo {{verse}} del capítulo {{chapter}}. Inserta el versículo que falta para arreglarlo.",
     "moreInfo": "Un capítulo debe contener marcadores de versículos para todos los versículos. Esto puede deberse a un error tipográfico o a la falta de un versículo. Inserte el versículo faltante para corregir este problema.",
-    "fixTitle": "Inserta el versículo que falta"
+    "fixTitle": "Inserta el versículo que falta",
+    "excludeFixTitle": "Excluir {{verseRef}} de la versificación"
   },
   "verseOutOfOrder": {
     "description": "El versículo {{verse}} aparece fuera de orden en el capítulo {{chapter}}.",

--- a/packages/punctuation-checker/src/abstract-checker.ts
+++ b/packages/punctuation-checker/src/abstract-checker.ts
@@ -2,7 +2,7 @@ import {
   activeDiagnosticsChanged$,
   allDiagnosticsChanged$,
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DiagnosticProvider,
   DiagnosticsChanged,
   DocumentAccessor,
@@ -22,6 +22,7 @@ export abstract class AbstractChecker<TDoc extends TextDocument | ScriptureDocum
   implements DiagnosticProvider<TEdit>
 {
   public readonly diagnosticsChanged$: Observable<DiagnosticsChanged>;
+  public readonly commands = new Set<string>();
   private readonly refreshSubject = new Subject<string>();
 
   constructor(
@@ -57,12 +58,16 @@ export abstract class AbstractChecker<TDoc extends TextDocument | ScriptureDocum
     return await this.validateDocument(doc);
   }
 
-  async getDiagnosticFixes(uri: string, diagnostic: Diagnostic): Promise<DiagnosticFix<TEdit>[]> {
+  async getDiagnosticActions(uri: string, diagnostic: Diagnostic): Promise<DiagnosticAction<TEdit>[]> {
     const doc = await this.documentAccessor.get(uri);
     if (doc == null) {
       return [];
     }
     return this.getFixes(doc, diagnostic);
+  }
+
+  executeCommand(_command: string, _uri: string, _diagnostic: Diagnostic): Promise<boolean> {
+    return Promise.resolve(false);
   }
 
   refresh(uri: string): Promise<void> {
@@ -99,5 +104,5 @@ export abstract class AbstractChecker<TDoc extends TextDocument | ScriptureDocum
     return diagnostics;
   }
 
-  protected abstract getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticFix<TEdit>[];
+  protected abstract getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticAction<TEdit>[];
 }

--- a/packages/punctuation-checker/src/allowed-character/allowed-character-checker.ts
+++ b/packages/punctuation-checker/src/allowed-character/allowed-character-checker.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DocumentAccessor,
   Localizer,
   ScriptureDocument,
@@ -39,7 +39,7 @@ export class AllowedCharacterChecker<
     this.localizer.addNamespace(ALLOWED_CHARACTER_CHECKER_LOCALIZER_NAMESPACE, createLocaleLoader('allowed-character'));
   }
 
-  protected getFixes(_document: TDoc, _diagnostic: Diagnostic): DiagnosticFix<TEdit>[] {
+  protected getFixes(_document: TDoc, _diagnostic: Diagnostic): DiagnosticAction<TEdit>[] {
     // no fixes available for disallowed characters
     return [];
   }

--- a/packages/punctuation-checker/src/fixes/standard-fixes.ts
+++ b/packages/punctuation-checker/src/fixes/standard-fixes.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   EditFactory,
   Localizer,
   Range,
@@ -20,7 +20,7 @@ class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit =
     private readonly localizer: Localizer,
   ) {}
 
-  public punctuationRemovalFix(diagnostic: Diagnostic): DiagnosticFix<TEdit> {
+  public punctuationRemovalFix(diagnostic: Diagnostic): DiagnosticAction<TEdit> {
     return {
       title: this.localizer.t(`punctuationRemovalFix`, {
         ns: LOCALIZER_NAMESPACE,
@@ -31,7 +31,7 @@ class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit =
     };
   }
 
-  public punctuationReplacementFix(diagnostic: Diagnostic, replacementCharacter: string): DiagnosticFix<TEdit> {
+  public punctuationReplacementFix(diagnostic: Diagnostic, replacementCharacter: string): DiagnosticAction<TEdit> {
     return {
       title: this.localizer.t(`punctuationReplacementFix`, {
         ns: LOCALIZER_NAMESPACE,
@@ -43,7 +43,7 @@ class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit =
     };
   }
 
-  public leadingSpaceInsertionFix(diagnostic: Diagnostic): DiagnosticFix<TEdit> {
+  public leadingSpaceInsertionFix(diagnostic: Diagnostic): DiagnosticAction<TEdit> {
     return {
       title: this.localizer.t(`leadingSpaceInsertionFix`, {
         ns: LOCALIZER_NAMESPACE,
@@ -71,7 +71,7 @@ class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit =
     };
   }
 
-  public trailingSpaceInsertionFix(diagnostic: Diagnostic): DiagnosticFix<TEdit> {
+  public trailingSpaceInsertionFix(diagnostic: Diagnostic): DiagnosticAction<TEdit> {
     return {
       title: this.localizer.t(`trailingSpaceInsertionFix`, {
         ns: LOCALIZER_NAMESPACE,
@@ -99,7 +99,7 @@ class StandardFixProvider<TDoc extends TextDocument | ScriptureDocument, TEdit =
     };
   }
 
-  public trailingStringInsertionFix(diagnostic: Diagnostic, stringToInsert: string): DiagnosticFix<TEdit> {
+  public trailingStringInsertionFix(diagnostic: Diagnostic, stringToInsert: string): DiagnosticAction<TEdit> {
     return {
       title: this.localizer.t(`trailingStringInsertionFix`, {
         ns: LOCALIZER_NAMESPACE,

--- a/packages/punctuation-checker/src/paired-punctuation/paired-punctuation-checker.ts
+++ b/packages/punctuation-checker/src/paired-punctuation/paired-punctuation-checker.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DocumentAccessor,
   EditFactory,
   Localizer,
@@ -61,7 +61,7 @@ export class PairedPunctuationChecker<
     await this.standardFixProviderFactory.init();
   }
 
-  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticFix<TEdit>[] {
+  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticAction<TEdit>[] {
     const standardFixProvider: StandardFixProvider<TDoc, TEdit> =
       this.standardFixProviderFactory.createStandardFixProvider(document);
     if (

--- a/packages/punctuation-checker/src/punctuation-context/punctuation-context-checker.ts
+++ b/packages/punctuation-checker/src/punctuation-context/punctuation-context-checker.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DocumentAccessor,
   EditFactory,
   Localizer,
@@ -52,7 +52,7 @@ export class PunctuationContextChecker<
     await this.standardFixProviderFactory.init();
   }
 
-  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticFix<TEdit>[] {
+  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticAction<TEdit>[] {
     // The only fix we offer is to insert a space
     if (!(diagnostic.data as WhitespaceDiagnosticData).isSpaceAllowed) {
       return [];

--- a/packages/punctuation-checker/src/quotation/quotation-checker.ts
+++ b/packages/punctuation-checker/src/quotation/quotation-checker.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DocumentAccessor,
   EditFactory,
   Localizer,
@@ -57,7 +57,7 @@ export class QuotationChecker<TDoc extends TextDocument | ScriptureDocument, TEd
     await this.standardFixProviderFactory.init();
   }
 
-  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticFix<TEdit>[] {
+  protected getFixes(document: TDoc, diagnostic: Diagnostic): DiagnosticAction<TEdit>[] {
     const standardFixProvider: StandardFixProvider<TDoc, TEdit> =
       this.standardFixProviderFactory.createStandardFixProvider(document);
 
@@ -85,8 +85,8 @@ export class QuotationChecker<TDoc extends TextDocument | ScriptureDocument, TEd
   private getIncorrectlyNestedQuoteFixes(
     diagnostic: Diagnostic,
     standardFixProvider: StandardFixProvider<TDoc, TEdit>,
-  ): DiagnosticFix<TEdit>[] {
-    const fixes: DiagnosticFix<TEdit>[] = [standardFixProvider.punctuationRemovalFix(diagnostic)];
+  ): DiagnosticAction<TEdit>[] {
+    const fixes: DiagnosticAction<TEdit>[] = [standardFixProvider.punctuationRemovalFix(diagnostic)];
     interface QuoteParentDepth {
       depth: number;
     }
@@ -111,7 +111,7 @@ export class QuotationChecker<TDoc extends TextDocument | ScriptureDocument, TEd
   private getAmbiguousQuoteFixes(
     diagnostic: Diagnostic,
     standardFixProvider: StandardFixProvider<TDoc, TEdit>,
-  ): DiagnosticFix<TEdit>[] {
+  ): DiagnosticAction<TEdit>[] {
     interface QuotationMarkCorrection {
       existingQuotationMark: string;
       correctedQuotationMark: string;
@@ -123,7 +123,7 @@ export class QuotationChecker<TDoc extends TextDocument | ScriptureDocument, TEd
   private getMissingQuoteContinuerFixes(
     diagnostic: Diagnostic,
     standardFixProvider: StandardFixProvider<TDoc, TEdit>,
-  ): DiagnosticFix<TEdit>[] {
+  ): DiagnosticAction<TEdit>[] {
     const quoteContinuersToInsert: string = diagnostic.data as string;
     return [standardFixProvider.trailingStringInsertionFix(diagnostic, quoteContinuersToInsert)];
   }

--- a/packages/punctuation-checker/test/abstract-checker.test.ts
+++ b/packages/punctuation-checker/test/abstract-checker.test.ts
@@ -1,6 +1,6 @@
 import {
   Diagnostic,
-  DiagnosticFix,
+  DiagnosticAction,
   DiagnosticSeverity,
   DocumentAccessor,
   DocumentManager,
@@ -285,7 +285,7 @@ class TestEnvironment {
         });
       }
 
-      protected getFixes(_document: T, _diagnostic: Diagnostic): DiagnosticFix[] {
+      protected getFixes(_document: T, _diagnostic: Diagnostic): DiagnosticAction[] {
         return [];
       }
     }

--- a/packages/punctuation-checker/test/allowed-character/allowed-character-checker.test.ts
+++ b/packages/punctuation-checker/test/allowed-character/allowed-character-checker.test.ts
@@ -28,7 +28,7 @@ describe('TextDocument tests', () => {
     await testEnv.init();
 
     expect(
-      await testEnv.allowedCharacterChecker.getDiagnosticFixes(
+      await testEnv.allowedCharacterChecker.getDiagnosticActions(
         'Hello, _there!&%',
         testEnv.createExpectedDiagnostic(',', 5, 6),
       ),

--- a/packages/punctuation-checker/test/paired-punctuation/paired-punctuation-checker.test.ts
+++ b/packages/punctuation-checker/test/paired-punctuation/paired-punctuation-checker.test.ts
@@ -11,7 +11,7 @@ describe('PairedPunctuationChecker tests', () => {
     await testEnv.init();
 
     expect(
-      await testEnv.pairedPunctuationChecker.getDiagnosticFixes('(Hello', {
+      await testEnv.pairedPunctuationChecker.getDiagnosticActions('(Hello', {
         code: 'unmatched-opening-parenthesis',
         source: 'paired-punctuation-checker',
         severity: DiagnosticSeverity.Error,
@@ -71,7 +71,7 @@ describe('PairedPunctuationChecker tests', () => {
     await testEnv.init();
 
     expect(
-      await testEnv.pairedPunctuationChecker.getDiagnosticFixes('(Hello\u201C) there\u201D', {
+      await testEnv.pairedPunctuationChecker.getDiagnosticActions('(Hello\u201C) there\u201D', {
         code: 'overlapping-punctuation-pairs',
         source: 'paired-punctuation-checker',
         severity: DiagnosticSeverity.Warning,

--- a/packages/punctuation-checker/test/punctuation-context/punctuation-context-checker.test.ts
+++ b/packages/punctuation-checker/test/punctuation-context/punctuation-context-checker.test.ts
@@ -12,7 +12,7 @@ describe('PunctuationContextChecker tests', () => {
     await testEnv.init();
 
     expect(
-      await testEnv.punctuationContextChecker.getDiagnosticFixes('No.space', {
+      await testEnv.punctuationContextChecker.getDiagnosticActions('No.space', {
         code: 'incorrect-trailing-context',
         severity: DiagnosticSeverity.Warning,
         range: {
@@ -73,7 +73,7 @@ describe('PunctuationContextChecker tests', () => {
     ]);
 
     expect(
-      await testEnv.punctuationContextChecker.getDiagnosticFixes('No(space', {
+      await testEnv.punctuationContextChecker.getDiagnosticActions('No(space', {
         code: 'incorrect-leading-context',
         severity: DiagnosticSeverity.Warning,
         range: {
@@ -141,7 +141,7 @@ describe('PunctuationContextChecker tests', () => {
     await testEnv.init();
 
     expect(
-      await testEnv.punctuationContextChecker.getDiagnosticFixes('No+space', {
+      await testEnv.punctuationContextChecker.getDiagnosticActions('No+space', {
         code: 'incorrect-trailing-context',
         severity: DiagnosticSeverity.Warning,
         range: {

--- a/packages/punctuation-checker/test/quotation/quotation-checker.test.ts
+++ b/packages/punctuation-checker/test/quotation/quotation-checker.test.ts
@@ -54,7 +54,7 @@ describe('QuotationChecker tests', () => {
       message: `Opening quotation mark with no closing mark.`,
     };
 
-    expect(await testEnv.quotationChecker.getDiagnosticFixes('', unmatchedOpeningQuoteDiagnostic)).toEqual([
+    expect(await testEnv.quotationChecker.getDiagnosticActions('', unmatchedOpeningQuoteDiagnostic)).toEqual([
       {
         title: 'Delete punctuation mark',
         isPreferred: false,
@@ -68,7 +68,7 @@ describe('QuotationChecker tests', () => {
       },
     ]);
 
-    expect(await testEnv.quotationChecker.getDiagnosticFixes('', unmatchedClosingQuoteDiagnostic)).toEqual([
+    expect(await testEnv.quotationChecker.getDiagnosticActions('', unmatchedClosingQuoteDiagnostic)).toEqual([
       {
         title: 'Delete punctuation mark',
         isPreferred: false,
@@ -107,7 +107,7 @@ describe('QuotationChecker tests', () => {
       },
     };
 
-    expect(await testEnv.quotationChecker.getDiagnosticFixes('', incorrectlyNestedDiagnostic)).toEqual([
+    expect(await testEnv.quotationChecker.getDiagnosticActions('', incorrectlyNestedDiagnostic)).toEqual([
       {
         title: 'Delete punctuation mark',
         isPreferred: false,
@@ -158,7 +158,7 @@ describe('QuotationChecker tests', () => {
       },
     };
 
-    expect(await testEnv.quotationChecker.getDiagnosticFixes('', ambiguousDiagnostic)).toEqual([
+    expect(await testEnv.quotationChecker.getDiagnosticActions('', ambiguousDiagnostic)).toEqual([
       {
         title: 'Replace this character with \u201C',
         isPreferred: true,
@@ -194,7 +194,7 @@ describe('QuotationChecker tests', () => {
       message: `Too many levels of quotation marks. Consider rephrasing to avoid this.`,
     };
 
-    expect(await testEnv.quotationChecker.getDiagnosticFixes('', tooDeeplyNestedDiagnostic)).toEqual([]);
+    expect(await testEnv.quotationChecker.getDiagnosticActions('', tooDeeplyNestedDiagnostic)).toEqual([]);
   });
 
   it('uses the QuotationConfig that is passed to it', async () => {


### PR DESCRIPTION
- rename `DiagnosticFix` to `DiagnosticAction`
- add `command` property to `DiagnosticAction`
- add `executeCommand` to `DiagnosticProvider`
- add `executeDiagnosticActionCommand` to `Workspace`
- throw exception when passing an invalid diagnostic to `Workspace` methods
- add documentation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lynx/61)
<!-- Reviewable:end -->
